### PR TITLE
Ec 89 prices with and without discount 3 02

### DIFF
--- a/ecommerce-app/src/components/ProductsList/ProductsList.tsx
+++ b/ecommerce-app/src/components/ProductsList/ProductsList.tsx
@@ -98,8 +98,14 @@ export default function ProductsList() {
                   <Chip label={price} size="small" />
                 </CardContent>
                 <CardActions>
-                  <Button size="small" sx={{ color: BUTTON_COLOR }}>
-                    Learn More
+                  <Button
+                    size="small"
+                    sx={{ color: BUTTON_COLOR }}
+                    onClick={(e) => {
+                      e.preventDefault();
+                    }}
+                  >
+                    Add to cart
                   </Button>
                 </CardActions>
               </CardActionArea>

--- a/ecommerce-app/src/components/ProductsList/ProductsList.tsx
+++ b/ecommerce-app/src/components/ProductsList/ProductsList.tsx
@@ -31,6 +31,9 @@ const CARD_TITLE_FONTSIZE = 18;
 const CARD_DESC_FONTSIZE = 14;
 const BUTTON_COLOR = "#F9C152";
 const CARD_DESC_MB = 1.5;
+const PRICE_MR = 1;
+const PRICE_BG_COLOR = "rgba(0, 0, 0, 0.08)";
+const DISCOUNT_BG_COLOR = "#00ffbb7d";
 
 export default function ProductsList() {
   const { errorMessage, loading, products, page, limit, filterParams } =
@@ -57,61 +60,85 @@ export default function ProductsList() {
   return (
     <div>
       <Grid container spacing={GRID_SPACING}>
-        {parsedProducts.map(({ id, name, description, image, price }) => (
-          <Grid md={MD_COLS} sm={SM_COLS} xs={XS_COLS} key={id}>
-            <Card
-              sx={{
-                maxWidth: CARD_MAX_WIDTH,
-                boxShadow: CARD_BOX_SHADOW,
-                minHeight: CARD_MIN_HEIGHT,
-                height: CARD_HEIGHT,
-                display: "flex",
-                flexWrap: "wrap",
-                ":hover": {
-                  boxShadow: 7,
-                },
-              }}
-            >
-              <CardActionArea component={Link} to={`/shop/${id}`}>
-                <CardMedia
-                  component="img"
-                  alt={name as unknown as string}
-                  height={CARD_MEDIA_HEIGHT}
-                  image={image.url}
-                />
-                <CardContent>
-                  <Typography
-                    gutterBottom
-                    variant="h4"
-                    component="h4"
-                    sx={{ fontSize: CARD_TITLE_FONTSIZE }}
-                  >
-                    {name}
-                  </Typography>
-                  <Typography
-                    variant="body2"
-                    color="text.secondary"
-                    sx={{ mb: CARD_DESC_MB, fontSize: CARD_DESC_FONTSIZE }}
-                  >
-                    {description as unknown as string}
-                  </Typography>
-                  <Chip label={price} size="small" />
-                </CardContent>
-                <CardActions>
-                  <Button
-                    size="small"
-                    sx={{ color: BUTTON_COLOR }}
-                    onClick={(e) => {
-                      e.preventDefault();
-                    }}
-                  >
-                    Add to cart
-                  </Button>
-                </CardActions>
-              </CardActionArea>
-            </Card>
-          </Grid>
-        ))}
+        {parsedProducts.map(
+          ({ id, name, description, image, price, discount }) => (
+            <Grid md={MD_COLS} sm={SM_COLS} xs={XS_COLS} key={id}>
+              <Card
+                sx={{
+                  maxWidth: CARD_MAX_WIDTH,
+                  boxShadow: CARD_BOX_SHADOW,
+                  minHeight: CARD_MIN_HEIGHT,
+                  height: CARD_HEIGHT,
+                  ":hover": {
+                    boxShadow: 7,
+                  },
+                }}
+              >
+                <CardActionArea
+                  component={Link}
+                  to={`/shop/${id}`}
+                  sx={{
+                    display: "flex",
+                    flexWrap: "wrap",
+                    justifyContent: "flex-start",
+                    alignContent: "space-between",
+                    height: "100%",
+                  }}
+                >
+                  <div>
+                    <CardMedia
+                      component="img"
+                      alt={name as unknown as string}
+                      height={CARD_MEDIA_HEIGHT}
+                      image={image.url}
+                    />
+                    <CardContent>
+                      <Typography
+                        gutterBottom
+                        variant="h4"
+                        component="h4"
+                        sx={{ fontSize: CARD_TITLE_FONTSIZE }}
+                      >
+                        {name}
+                      </Typography>
+                      <Typography
+                        variant="body2"
+                        color="text.secondary"
+                        sx={{ mb: CARD_DESC_MB, fontSize: CARD_DESC_FONTSIZE }}
+                      >
+                        {description as unknown as string}
+                      </Typography>
+                      <Chip
+                        label={discount ? discount : price}
+                        size="small"
+                        sx={{
+                          mr: PRICE_MR,
+                          background: discount
+                            ? DISCOUNT_BG_COLOR
+                            : PRICE_BG_COLOR,
+                        }}
+                      />
+                      <span className="discount">
+                        {discount ? price : discount}
+                      </span>
+                    </CardContent>
+                  </div>
+                  <CardActions>
+                    <Button
+                      size="small"
+                      sx={{ color: BUTTON_COLOR }}
+                      onClick={(e) => {
+                        e.preventDefault();
+                      }}
+                    >
+                      Add to cart
+                    </Button>
+                  </CardActions>
+                </CardActionArea>
+              </Card>
+            </Grid>
+          ),
+        )}
       </Grid>
     </div>
   );

--- a/ecommerce-app/src/styles/App.css
+++ b/ecommerce-app/src/styles/App.css
@@ -33,3 +33,8 @@ h2 {
   flex-direction: column;
   justify-content: center;
 }
+
+.discount {
+  text-decoration: line-through;
+  color: darkgrey;
+}

--- a/ecommerce-app/src/types/index.ts
+++ b/ecommerce-app/src/types/index.ts
@@ -55,6 +55,7 @@ export interface IParcedProduct {
   designer: string;
   sizeList: string;
   color: string;
+  discount: string;
 }
 export interface IProductsFormattedAttribute {
   name: string;


### PR DESCRIPTION
## RSS-ECOMM-3_02: Display Prices with and Without Discount for Discounted Products 
Screenshot: 
![discount-price](https://github.com/JYMTeam/eCommerce-Application/assets/86577066/6ca4f342-4506-4f8f-957c-3d9f308e0832)

### Done 01.08.2023 / deadline 04.08.2023
### Description
- For discounted products 💸, the application should display both the original and the discounted price 💰. The discounted price, which is the current price the customer needs to pay, should be made visually distinct to highlight the discount and value for the customer 👀.
### Changes
- [x] Both the original price and the discounted price are clearly displayed for discounted products.
- [x] The discounted price is visually distinct and clearly indicates that it is the current price the customer needs to pay.
- [x] If the original price is displayed, it should be marked in a way that clearly communicates that it is not the current price (e.g., strikethrough).
- [x] fix: cards layout
- [x] filters 
